### PR TITLE
Update the World Pay gateway URLs

### DIFF
--- a/lib/active_merchant/billing/gateways/world_pay.rb
+++ b/lib/active_merchant/billing/gateways/world_pay.rb
@@ -2,8 +2,8 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class WorldPayGateway < Gateway  
       
-      TEST_URL = 'https://secure-test.wp3.rbsworldpay.com/jsp/merchant/xml/paymentService.jsp'
-      LIVE_URL = 'https://secure.wp3.rbsworldpay.com/jsp/merchant/xml/paymentService.jsp'
+      TEST_URL = 'https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp'
+      LIVE_URL = 'https://secure.worldpay.com/jsp/merchant/xml/paymentService.jsp'
       
       CREDIT_CARDS = {
         :visa             => "VISA-SSL",


### PR DESCRIPTION
Between 25/09/2018 and 02/10/2018 World Pay switched off their old branded URLs like secure.wp3.rbsworldpay.com
Replacing these URLs with the updated versions at secure.worldpay.com

See http://offers.worldpayglobal.com/WPG-URL-decommissioning2.html for more

Update to tutorhub repo using this change to follow after.